### PR TITLE
Peering request AS4242420263 at chr-am02

### DIFF
--- a/amsterdam.yaml
+++ b/amsterdam.yaml
@@ -87,3 +87,15 @@ dn42_peers:
     bgp:
       asn: '4242423914'
       session: 'mp'
+
+  - name: 'nl-ams1.flap42.eu'
+    contacts: 'https://hcartiaux.github.io/dn42'
+    wireguard:
+      endpoint_address: 'nl-ams1.flap42.eu'
+      endpoint_port: '51825'
+      public_key: 'osOFClUbgPmF9XVWhUtvatWjM0y0ZgTi0xnitirnphA='
+    address:
+      ipv6: 'fe80::105'
+    bgp:
+      asn: '4242420263'
+      session: 'mp'


### PR DESCRIPTION
As the title says, this is a peering request, between `nl-ams1.flap.42.eu` and `chr-am02.as215887.net`.

You'll find more information on my network here: https://hcartiaux.github.io/dn42/

The wireguard tunnel and ebgp session is already configured on my system.

Thank you,

Best,

Hyacinthe